### PR TITLE
[SFSRAP-25] Added plugin properties to support embed analyzers

### DIFF
--- a/RoslynPluginGenerator/Resources/RoslynProperties.java
+++ b/RoslynPluginGenerator/Resources/RoslynProperties.java
@@ -24,4 +24,20 @@ public final class RoslynProperties {
 	.defaultValue("[ROSLYN_NUGET_PACKAGE_VERSION]")
 	.hidden()
 	.build();
+
+  public static PropertyDefinition AnalyzerResourceName = PropertyDefinition.builder(PluginRulesDefinition.REPOSITORY_ID + ".staticResourceName")
+	.defaultValue("[ROSLYN_STATIC_RESOURCENAME]")
+	.hidden()
+	.build();
+
+  public static PropertyDefinition PluginKey = PropertyDefinition.builder(PluginRulesDefinition.REPOSITORY_ID + ".pluginKey")
+	.defaultValue("[ROSLYN_PLUGIN_KEY]")
+	.hidden()
+	.build();
+
+  public static PropertyDefinition PluginVersion = PropertyDefinition.builder(PluginRulesDefinition.REPOSITORY_ID + ".pluginVersion")
+	.defaultValue("[ROSLYN_PLUGIN_VERSION]")
+	.hidden()
+	.build();
+
 }

--- a/RoslynPluginGenerator/RoslynPluginDefinition.cs
+++ b/RoslynPluginGenerator/RoslynPluginDefinition.cs
@@ -1,0 +1,27 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RoslynPluginDefinition.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace SonarQube.Plugins.Roslyn
+{
+    /// <summary>
+    /// Data class: contains the information required to create a Roslyn analyzer plugin
+    /// </summary>
+    internal class RoslynPluginDefinition
+    {
+        public string Language { get; set; }
+        public string PackageId { get; set; }
+        public string PackageVersion { get; set; }
+        public PluginManifest Manifest { get; set; }
+        public string SqaleFilePath { get; set; }
+        public string RulesFilePath { get; set; }
+
+        /// <summary>
+        /// Name of the zip file containing the assemblies to be embedded in the jar as a static resource
+        /// </summary>
+        public string EmbeddedZipFileName { get; set; }
+    }
+}

--- a/RoslynPluginGenerator/SonarQube.Plugins.Roslyn.PluginGenerator.csproj
+++ b/RoslynPluginGenerator/SonarQube.Plugins.Roslyn.PluginGenerator.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AnalyzerPluginGenerator.cs" />
+    <Compile Include="RoslynPluginDefinition.cs" />
     <Compile Include="RuleGenerator.cs" />
     <Compile Include="SupportedLanguages.cs" />
     <Compile Include="UIResources.Designer.cs">

--- a/Tests/IntegrationTests/Roslyn/RoslynGenTests.cs
+++ b/Tests/IntegrationTests/Roslyn/RoslynGenTests.cs
@@ -70,13 +70,16 @@ namespace SonarQube.Plugins.IntegrationTests
             AssertExpectedPropertyDefinitionValue("analyzer1.pkgid1.ruleNamespace", "Analyzer1.Pkgid1", jarInfo);
             AssertExpectedPropertyDefinitionValue("analyzer1.pkgid1.nuget.packageId", "Analyzer1.Pkgid1", jarInfo);
             AssertExpectedPropertyDefinitionValue("analyzer1.pkgid1.nuget.packageVersion", "1.0.2", jarInfo);
+            AssertExpectedPropertyDefinitionValue("analyzer1.pkgid1.staticResourceName", "Analyzer1.Pkgid1.zip", jarInfo);
+            AssertExpectedPropertyDefinitionValue("analyzer1.pkgid1.pluginKey", "analyzer1.pkgid1", jarInfo);
+            AssertExpectedPropertyDefinitionValue("analyzer1.pkgid1.pluginVersion", "1.0.2", jarInfo);
 
             JarInfo.RulesDefinition rulesDefn = AssertRulesDefinitionExists(jarInfo);
             AssertRepositoryIsValid(rulesDefn.Repository);
             AssertExpectedRulesExist(analyzer, rulesDefn.Repository);
             Assert.AreEqual("roslyn.analyzer1.pkgid1", rulesDefn.Repository.Key, "Unexpected repository key");
 
-            Assert.AreEqual(5, jarInfo.Extensions.Count, "Unexpected number of extensions");
+            Assert.AreEqual(8, jarInfo.Extensions.Count, "Unexpected number of extensions");
         }
 
         #region Private methods


### PR DESCRIPTION
TODO: zip and embed the analzyer assemblies

The C# plugin requires extra information to be able to generate the _roslyn-cs_ profile, namely the plugin key and version, and the name of the zip file containing the embedded assemblies