### PR TITLE
[SFSRAP-34] Amended sqale file handling

### DIFF
--- a/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
+++ b/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
@@ -38,7 +38,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
             Descriptors.Add(new ArgumentDescriptor(
                 id: KeywordIds.AnalyzerRef, prefixes: new string[] { "/analyzer:", "/a:" }, required: true, allowMultiple: false, description: CmdLineResources.ArgDescription_AnalzyerRef));
             Descriptors.Add(new ArgumentDescriptor(
-                id: KeywordIds.SqaleXmlFile, prefixes: new string[] { "/sqale:", "/s:" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_SqaleXmlFile));
+                id: KeywordIds.SqaleXmlFile, prefixes: new string[] { "/sqale:" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_SqaleXmlFile));
 
             Debug.Assert(Descriptors.All(d => d.Prefixes != null && d.Prefixes.Any()), "All descriptors must provide at least one prefix");
             Debug.Assert(Descriptors.Select(d => d.Id).Distinct().Count() == Descriptors.Count, "All descriptors must have a unique id");

--- a/RoslynPluginGenerator/HardcodedConstantSqaleGenerator.cs
+++ b/RoslynPluginGenerator/HardcodedConstantSqaleGenerator.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="SqaleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+// <copyright file="HardcodedConstantSqaleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
 //   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
 //   Licensed under the MIT License. See License.txt in the project root for license information.
 // </copyright>

--- a/RoslynPluginGenerator/UIResources.Designer.cs
+++ b/RoslynPluginGenerator/UIResources.Designer.cs
@@ -124,6 +124,15 @@ namespace SonarQube.Plugins.Roslyn {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The specified SQALE file is invalid: {0}.
+        /// </summary>
+        public static string APG_InvalidSqaleFile {
+            get {
+                return ResourceManager.GetString("APG_InvalidSqaleFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Looking for analyzers in the package....
         /// </summary>
         public static string APG_LocatingAnalyzers {
@@ -183,6 +192,17 @@ namespace SonarQube.Plugins.Roslyn {
         public static string APG_SqaleGeneratedToFile {
             get {
                 return ResourceManager.GetString("APG_SqaleGeneratedToFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///A template SQALE file was saved to {0}. To use the template, fill in the appropriate remediation information for each rule, then re-run this generator specifying the sqale file to use with the /sqale:[filename] argument.
+        ///.
+        /// </summary>
+        public static string APG_TemplateSqaleFileGenerated {
+            get {
+                return ResourceManager.GetString("APG_TemplateSqaleFileGenerated", resourceCulture);
             }
         }
         

--- a/RoslynPluginGenerator/UIResources.Designer.cs
+++ b/RoslynPluginGenerator/UIResources.Designer.cs
@@ -197,7 +197,10 @@ namespace SonarQube.Plugins.Roslyn {
         
         /// <summary>
         ///   Looks up a localized string similar to 
-        ///A template SQALE file was saved to {0}. To use the template, fill in the appropriate remediation information for each rule, then re-run this generator specifying the sqale file to use with the /sqale:[filename] argument.
+        ///SQALE: an empty SQALE file for the analyzer was saved to {0}. To provide SQALE remediation information for the analyzer:
+        /// * rename the file
+        /// * fill in the appropriate remediation information for each diagnostic
+        /// * re-run this generator specifying the sqale file to use with the /sqale:[filename] argument.
         ///.
         /// </summary>
         public static string APG_TemplateSqaleFileGenerated {

--- a/RoslynPluginGenerator/UIResources.resx
+++ b/RoslynPluginGenerator/UIResources.resx
@@ -164,7 +164,10 @@
   </data>
   <data name="APG_TemplateSqaleFileGenerated" xml:space="preserve">
     <value>
-A template SQALE file was saved to {0}. To use the template, fill in the appropriate remediation information for each rule, then re-run this generator specifying the sqale file to use with the /sqale:[filename] argument.
+SQALE: an empty SQALE file for the analyzer was saved to {0}. To provide SQALE remediation information for the analyzer:
+ * rename the file
+ * fill in the appropriate remediation information for each diagnostic
+ * re-run this generator specifying the sqale file to use with the /sqale:[filename] argument.
 </value>
   </data>
   <data name="APG_UnsupportedLanguage" xml:space="preserve">

--- a/RoslynPluginGenerator/UIResources.resx
+++ b/RoslynPluginGenerator/UIResources.resx
@@ -138,6 +138,9 @@
   <data name="APG_GeneratingRules" xml:space="preserve">
     <value>Generating rules...</value>
   </data>
+  <data name="APG_InvalidSqaleFile" xml:space="preserve">
+    <value>The specified SQALE file is invalid: {0}</value>
+  </data>
   <data name="APG_LocatingAnalyzers" xml:space="preserve">
     <value>Looking for analyzers in the package...</value>
   </data>
@@ -158,6 +161,11 @@
   </data>
   <data name="APG_SqaleGeneratedToFile" xml:space="preserve">
     <value>SQALE generated to file {0}</value>
+  </data>
+  <data name="APG_TemplateSqaleFileGenerated" xml:space="preserve">
+    <value>
+A template SQALE file was saved to {0}. To use the template, fill in the appropriate remediation information for each rule, then re-run this generator specifying the sqale file to use with the /sqale:[filename] argument.
+</value>
   </data>
   <data name="APG_UnsupportedLanguage" xml:space="preserve">
     <value>The language '{0}' is not supported. Valid options are 'cs' or 'vb'.</value>

--- a/Tests/IntegrationTests/Roslyn/Resources/PluginInspector.java
+++ b/Tests/IntegrationTests/Roslyn/Resources/PluginInspector.java
@@ -54,7 +54,6 @@ public class PluginInspector  {
 
         if (args.length != 1 && args.length != 2){
             Log("Expecting at least one argument: the full path to the jar file.\r\nOptionally, the name of the file to be created may also be supplied.");
-            //          jarPath = "C:\\SonarQube\\sonarqube-5.2\\extensions\\plugins\\analyzer1pkgid1-plugin-1.0.2.jar";
             System.exit(ErrorCode);
         }
         else{

--- a/Tests/RoslynPluginGeneratorTests/ArgumentProcessorTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/ArgumentProcessorTests.cs
@@ -117,7 +117,7 @@ namespace SonarQube.Plugins.Roslyn.PluginGeneratorTests
 
             // 2. Missing sqale file
             logger = new TestLogger();
-            rawArgs = new string[] { "/s:missingFile.txt", "/a:validId" };
+            rawArgs = new string[] { "/sqale:missingFile.txt", "/a:validId" };
             actualArgs = ArgumentProcessor.TryProcessArguments(rawArgs, logger);
 
             AssertArgumentsNotProcessed(actualArgs, logger);
@@ -128,7 +128,7 @@ namespace SonarQube.Plugins.Roslyn.PluginGeneratorTests
             string filePath = TestUtils.CreateTextFile("valid.sqale.txt", testDir, "sqale file contents");
             
             logger = new TestLogger();
-            rawArgs = new string[] { "/s:" + filePath,  "/a:valid:1.0" };
+            rawArgs = new string[] { "/sqale:" + filePath,  "/a:valid:1.0" };
             actualArgs = ArgumentProcessor.TryProcessArguments(rawArgs, logger);
 
             AssertArgumentsProcessed(actualArgs, logger, "valid", "1.0", filePath);

--- a/Tests/RoslynPluginGeneratorTests/SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.csproj
+++ b/Tests/RoslynPluginGeneratorTests/SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.csproj
@@ -135,6 +135,10 @@
       <Project>{ff1a3253-1888-412c-a870-922c08b29a1a}</Project>
       <Name>SonarQube.Plugins.Roslyn.PluginGenerator</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\SonarLint.Metadata\SonarLint.Metadata.csproj">
+      <Project>{fd1e676b-a621-494b-9e2f-083940100415}</Project>
+      <Name>SonarLint.Metadata</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Common\SonarQube.Plugins.Test.Common.csproj">
       <Project>{f60478ff-1eea-4fb4-9bf4-50d11f94fa57}</Project>
       <Name>SonarQube.Plugins.Test.Common</Name>


### PR DESCRIPTION
Changed the sqale file handling to match the experience described in the issue:
* create a template sqale file if the user doesn't specify one, but don't include it in the jar
* otherwise embed the supplied sqale file
Added basic validation for the supplied sqale file