### PR TITLE
[SFSRAP-39] Amended dependency retrieval

### DIFF
--- a/RoslynPluginGenerator/AnalyzerPluginGenerator.cs
+++ b/RoslynPluginGenerator/AnalyzerPluginGenerator.cs
@@ -167,23 +167,10 @@ namespace SonarQube.Plugins.Roslyn
         /// <returns>Returns true if any of the packages in the dependency tree require license acceptance.</returns>
         private bool PackageRequiresLicenseAcceptance(IPackage package)
         {
-            if (package.RequireLicenseAcceptance)
-            {
-                return true;
-            }
-            foreach (PackageDependencySet dependencySet in package.DependencySets)
-            {
-                foreach (PackageDependency dependency in dependencySet.Dependencies)
-                {
-                    // Also check that no dependencies require license acceptance
-                    IPackage dependencyPkg = packageHandler.FetchPackage(dependency.Id, dependency.VersionSpec.MaxVersion);
-                    if (PackageRequiresLicenseAcceptance(dependencyPkg))
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
+            bool licenseRequired = package.RequireLicenseAcceptance 
+                || this.packageHandler.GetInstalledDependencies(package).Any(d => d.RequireLicenseAcceptance);
+
+            return licenseRequired;
         }
 
         /// <summary>

--- a/RoslynPluginGenerator/Interfaces/INuGetPackageHandler.cs
+++ b/RoslynPluginGenerator/Interfaces/INuGetPackageHandler.cs
@@ -28,6 +28,12 @@ namespace SonarQube.Plugins.Roslyn
         IPackage FetchPackage(string packageId, SemanticVersion version);
 
         /// <summary>
+        /// Returns the closure of packages required by the specified package
+        /// that have been installed locally
+        /// </summary>
+        IEnumerable<IPackage> GetInstalledDependencies(IPackage package);
+
+        /// <summary>
         /// Returns the local directory containing the specified package
         /// </summary>
         /// <remarks>Assumes that the package has already been fetched</remarks>

--- a/RoslynPluginGenerator/UIResources.Designer.cs
+++ b/RoslynPluginGenerator/UIResources.Designer.cs
@@ -239,6 +239,15 @@ namespace SonarQube.Plugins.Roslyn {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to   Adding new dependency: {0} version {1}.
+        /// </summary>
+        public static string NG_AddingNewDependency {
+            get {
+                return ResourceManager.GetString("NG_AddingNewDependency", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Creating NuGet repository: {0}.
         /// </summary>
         public static string NG_CreatingRepository {
@@ -262,6 +271,15 @@ namespace SonarQube.Plugins.Roslyn {
         public static string NG_DownloadingPackage {
             get {
                 return ResourceManager.GetString("NG_DownloadingPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to   Duplicate dependency: {0} version {1}.
+        /// </summary>
+        public static string NG_DuplicateDependency {
+            get {
+                return ResourceManager.GetString("NG_DuplicateDependency", resourceCulture);
             }
         }
         
@@ -299,6 +317,15 @@ namespace SonarQube.Plugins.Roslyn {
         public static string NG_ExtractingFile {
             get {
                 return ResourceManager.GetString("NG_ExtractingFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to resolve dependency: {0} version {1}.
+        /// </summary>
+        public static string NG_FailedToResolveDependency {
+            get {
+                return ResourceManager.GetString("NG_FailedToResolveDependency", resourceCulture);
             }
         }
         
@@ -381,6 +408,15 @@ namespace SonarQube.Plugins.Roslyn {
         public static string NG_PackageVersionListHeader {
             get {
                 return ResourceManager.GetString("NG_PackageVersionListHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resolving dependencies for {0} version {1}....
+        /// </summary>
+        public static string NG_ResolvingPackageDependencies {
+            get {
+                return ResourceManager.GetString("NG_ResolvingPackageDependencies", resourceCulture);
             }
         }
         

--- a/RoslynPluginGenerator/UIResources.resx
+++ b/RoslynPluginGenerator/UIResources.resx
@@ -181,6 +181,9 @@ SQALE: an empty SQALE file for the analyzer was saved to {0}. To provide SQALE r
 * NuGet package Id (mandatory), and
 * NuGet package version (optional)</value>
   </data>
+  <data name="NG_AddingNewDependency" xml:space="preserve">
+    <value>  Adding new dependency: {0} version {1}</value>
+  </data>
   <data name="NG_CreatingRepository" xml:space="preserve">
     <value>Creating NuGet repository: {0}</value>
   </data>
@@ -189,6 +192,9 @@ SQALE: an empty SQALE file for the analyzer was saved to {0}. To provide SQALE r
   </data>
   <data name="NG_DownloadingPackage" xml:space="preserve">
     <value>Downloading package...</value>
+  </data>
+  <data name="NG_DuplicateDependency" xml:space="preserve">
+    <value>  Duplicate dependency: {0} version {1}</value>
   </data>
   <data name="NG_ERROR_PackageInstallFail" xml:space="preserve">
     <value>Failed to install package: {0}
@@ -202,6 +208,9 @@ Check that there are released versions of the package, or specify a pre-release 
   </data>
   <data name="NG_ExtractingFile" xml:space="preserve">
     <value>Extracting file '{0}' to {1}</value>
+  </data>
+  <data name="NG_FailedToResolveDependency" xml:space="preserve">
+    <value>Failed to resolve dependency: {0} version {1}</value>
   </data>
   <data name="NG_FetchingConfigFiles" xml:space="preserve">
     <value>Fetching NuGet config files...</value>
@@ -230,6 +239,9 @@ The conflict will be ignored.</value>
   </data>
   <data name="NG_PackageVersionListHeader" xml:space="preserve">
     <value>Package versions:</value>
+  </data>
+  <data name="NG_ResolvingPackageDependencies" xml:space="preserve">
+    <value>Resolving dependencies for {0} version {1}...</value>
   </data>
   <data name="NG_SelectedPackageVersion" xml:space="preserve">
     <value>Version was not specified. Using version {0}.</value>


### PR DESCRIPTION
Changed NuGet dependency retrieval to "ResolveDependency" rather than walking the dependency sets ourselves.
Added logging.
Added interface method to return the dependencies

TODO: create the jar if the user has set */acceptLicenses*