### PR TITLE
[SFSRAP-37] Added a data class for the new sdk config

### DIFF
--- a/RoslynPluginGenerator/DataModel/PluginProperties.cs
+++ b/RoslynPluginGenerator/DataModel/PluginProperties.cs
@@ -1,0 +1,60 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="PluginProperties.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Collections.Specialized;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+
+namespace SonarQube.Plugins.Roslyn
+{
+    /// <summary>
+    /// Describes a collection of Maven POM properties
+    /// </summary>
+    /// <remarks>This class is XML-serializable</remarks>
+    public class PluginProperties : StringDictionary, IXmlSerializable
+    {
+        #region IXmlSerializable methods
+
+        // Custom serialization to allow reading/writing to the following format:
+        //  <properties>
+        //      <sonarUpdateCenter.version>1.11</sonarUpdateCenter.version>
+        //      <sonarJava.version>2.4</sonarJava.version>
+        //      <h2.version>1.3.172</h2.version>
+        //      ...
+        //  </properties>
+
+        // The name of the containing element (e.g. "properties") is set by
+        // containing object using the XmlElement property e.g. [XmlElement("PluginProperties")]
+        
+        XmlSchema IXmlSerializable.GetSchema()
+        {
+            return null;
+        }
+
+        void IXmlSerializable.ReadXml(XmlReader reader)
+        {
+            reader.ReadStartElement();
+
+            while (reader.IsStartElement())
+            {
+                this.Add(reader.Name, reader.ReadElementContentAsString());
+            }
+            reader.ReadEndElement();
+        }
+
+        void IXmlSerializable.WriteXml(XmlWriter writer)
+        {
+            foreach (string key in this.Keys)
+            {
+                writer.WriteElementString(key, this[key]);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/RoslynPluginGenerator/DataModel/RoslynSdkConfiguration.cs
+++ b/RoslynPluginGenerator/DataModel/RoslynSdkConfiguration.cs
@@ -1,0 +1,71 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RoslynSdkConfiguration.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+using System;
+using System.Xml.Serialization;
+
+namespace SonarQube.Plugins.Roslyn
+{
+    public class RoslynSdkConfiguration
+    {
+        public RoslynSdkConfiguration()
+        {
+            this.Properties = new PluginProperties();
+        }
+
+        public string PluginKeyDifferentiator { get; set; }
+
+        public string RepositoryKey { get; set; }
+
+        public string RepositoryLanguage { get; set; }
+
+        public string RepositoryName { get; set; }
+
+        public string RulesXmlResourcePath { get; set; }
+
+        public string SqaleXmlResourcePath { get; set; }
+
+        [XmlElement("PluginProperties")]
+        public PluginProperties Properties { get; set; }
+
+        #region Serialization
+
+        [XmlIgnore]
+        public string FileName { get; private set; }
+
+        /// <summary>
+        /// Saves the project to the specified file as XML
+        /// </summary>
+        public void Save(string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                throw new ArgumentNullException("fileName");
+            }
+
+            this.FileName = fileName;
+
+            Serializer.SaveModel(this, fileName);
+        }
+
+        /// <summary>
+        /// Loads and returns rules from the specified XML file
+        /// </summary>
+        public static RoslynSdkConfiguration Load(string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                throw new ArgumentNullException("fileName");
+            }
+
+            RoslynSdkConfiguration model = Serializer.LoadModel<RoslynSdkConfiguration>(fileName);
+            model.FileName = fileName;
+            return model;
+        }
+
+        #endregion Serialization
+    }
+}

--- a/RoslynPluginGenerator/SonarQube.Plugins.Roslyn.PluginGenerator.csproj
+++ b/RoslynPluginGenerator/SonarQube.Plugins.Roslyn.PluginGenerator.csproj
@@ -108,6 +108,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommandLine\ArgumentProcessor.cs" />
+    <Compile Include="DataModel\PluginProperties.cs" />
     <Compile Include="DiagnosticAssemblyScanner.cs" />
     <Compile Include="Interfaces\INuGetPackageHandler.cs" />
     <Compile Include="Interfaces\IRuleGenerator.cs" />
@@ -121,6 +122,7 @@
     </Compile>
     <Compile Include="NuGet\NuGetPackageHandler.cs" />
     <Compile Include="NuGet\NuGetRepositoryFactory.cs" />
+    <Compile Include="DataModel\RoslynSdkConfiguration.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\AssemblyInfo.Shared.cs">

--- a/Tests/RoslynPluginGeneratorTests/RoslynSdkConfigurationTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/RoslynSdkConfigurationTests.cs
@@ -74,13 +74,13 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
   <RulesXmlResourcePath>/org/sonar/plugins/roslynsdk/rules.xml</RulesXmlResourcePath>
   <SqaleXmlResourcePath>/org/sonar/plugins/roslynsdk/sqale.xml</SqaleXmlResourcePath>
   <PluginProperties>
-    <example.pluginKey>example</example.pluginKey>
-    <example.pluginVersion>example</example.pluginVersion>
-    <example.staticResourceName>example</example.staticResourceName>
-    <example.nuget.packageId>example</example.nuget.packageId>
-    <example.nuget.packageVersion>example</example.nuget.packageVersion>
-    <example.analyzerId>example</example.analyzerId>
-    <example.ruleNamespace>example</example.ruleNamespace>
+    <example.pluginKey>example.pluginKey.Value</example.pluginKey>
+    <example.pluginVersion>example.pluginVersion.Value</example.pluginVersion>
+    <example.staticResourceName>example.staticResourceName.Value</example.staticResourceName>
+    <example.nuget.packageId>example.nuget.packageId.Value</example.nuget.packageId>
+    <example.nuget.packageVersion>example.nuget.packageVersion.Value</example.nuget.packageVersion>
+    <example.analyzerId>example.analyzerId.Value</example.analyzerId>
+    <example.ruleNamespace>example.ruleNamespace.Value</example.ruleNamespace>
   </PluginProperties>
 </RoslynSdkConfiguration>
 ";
@@ -105,13 +105,13 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
             Assert.AreEqual("/org/sonar/plugins/roslynsdk/rules.xml", loaded.RulesXmlResourcePath);
             Assert.AreEqual("/org/sonar/plugins/roslynsdk/sqale.xml", loaded.SqaleXmlResourcePath);
 
-            AssertPropertyExists("example.pluginKey", "example", loaded.Properties);
-            AssertPropertyExists("example.pluginVersion", "example", loaded.Properties);
-            AssertPropertyExists("example.staticResourceName", "example", loaded.Properties);
-            AssertPropertyExists("example.nuget.packageId", "example", loaded.Properties);
-            AssertPropertyExists("example.nuget.packageVersion", "example", loaded.Properties);
-            AssertPropertyExists("example.analyzerId", "example", loaded.Properties);
-            AssertPropertyExists("example.ruleNamespace", "example", loaded.Properties);
+            AssertPropertyExists("example.pluginKey", "example.pluginKey.Value", loaded.Properties);
+            AssertPropertyExists("example.pluginVersion", "example.pluginVersion.Value", loaded.Properties);
+            AssertPropertyExists("example.staticResourceName", "example.staticResourceName.Value", loaded.Properties);
+            AssertPropertyExists("example.nuget.packageId", "example.nuget.packageId.Value", loaded.Properties);
+            AssertPropertyExists("example.nuget.packageVersion", "example.nuget.packageVersion.Value", loaded.Properties);
+            AssertPropertyExists("example.analyzerId", "example.analyzerId.Value", loaded.Properties);
+            AssertPropertyExists("example.ruleNamespace", "example.ruleNamespace.Value", loaded.Properties);
         }
 
         #endregion

--- a/Tests/RoslynPluginGeneratorTests/RoslynSdkConfigurationTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/RoslynSdkConfigurationTests.cs
@@ -1,0 +1,130 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RoslynSdkConfigurationTests.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarQube.Plugins.Test.Common;
+using System.IO;
+
+namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
+{
+    [TestClass]
+    public class RoslynSdkConfigurationTests
+    {
+        public TestContext TestContext { get; set; }
+
+        #region Tests
+
+        [TestMethod]
+        public void SdkConfig_SaveAndReload_Succeeds()
+        {
+            // Arrange
+            string testDir = TestUtils.CreateTestDirectory(this.TestContext);
+            string filePath = Path.Combine(testDir, "original.txt");
+
+
+            RoslynSdkConfiguration config = new RoslynSdkConfiguration();
+
+            config.PluginKeyDifferentiator = "diff";
+            config.RepositoryKey = "key";
+            config.RepositoryName = "repo.name";
+            config.RepositoryLanguage = "language";
+            config.RulesXmlResourcePath = "rulesPath";
+            config.SqaleXmlResourcePath = "sqalePath";
+
+            config.Properties["prop1.key"] = "value1";
+            config.Properties["prop2.key"] = "value2";
+
+            // Save and check 
+            config.Save(filePath);
+            Assert.AreEqual(filePath, config.FileName);
+            this.TestContext.AddResultFile(filePath);
+
+            // Reload and check
+            RoslynSdkConfiguration reloaded = RoslynSdkConfiguration.Load(filePath);
+
+            Assert.IsNotNull(reloaded);
+
+            Assert.AreEqual("diff", reloaded.PluginKeyDifferentiator);
+            Assert.AreEqual("key", reloaded.RepositoryKey);
+            Assert.AreEqual("repo.name", reloaded.RepositoryName);
+            Assert.AreEqual("language", reloaded.RepositoryLanguage);
+            Assert.AreEqual("rulesPath", reloaded.RulesXmlResourcePath);
+            Assert.AreEqual("sqalePath", reloaded.SqaleXmlResourcePath);
+
+            Assert.AreEqual(2, reloaded.Properties.Count);
+            AssertPropertyExists("prop1.key", "value1", reloaded.Properties);
+            AssertPropertyExists("prop2.key", "value2", reloaded.Properties);
+        }
+
+        [TestMethod]
+        public void SdkConfig_LoadRealExample_Succeeds()
+        {
+            // Arrange
+            #region File content
+
+            string exampleConfig = @"<RoslynSdkConfiguration>
+  <PluginKeyDifferentiator>example</PluginKeyDifferentiator>
+  <RepositoryKey>roslyn.example</RepositoryKey>
+  <RepositoryLanguage>example</RepositoryLanguage>
+  <RepositoryName>example</RepositoryName>
+  <RulesXmlResourcePath>/org/sonar/plugins/roslynsdk/rules.xml</RulesXmlResourcePath>
+  <SqaleXmlResourcePath>/org/sonar/plugins/roslynsdk/sqale.xml</SqaleXmlResourcePath>
+  <PluginProperties>
+    <example.pluginKey>example</example.pluginKey>
+    <example.pluginVersion>example</example.pluginVersion>
+    <example.staticResourceName>example</example.staticResourceName>
+    <example.nuget.packageId>example</example.nuget.packageId>
+    <example.nuget.packageVersion>example</example.nuget.packageVersion>
+    <example.analyzerId>example</example.analyzerId>
+    <example.ruleNamespace>example</example.ruleNamespace>
+  </PluginProperties>
+</RoslynSdkConfiguration>
+";
+
+            #endregion
+
+            string testDir = TestUtils.CreateTestDirectory(this.TestContext);
+            string filePath = TestUtils.CreateTextFile("realPluginProperties.txt", testDir, exampleConfig);
+            this.TestContext.AddResultFile(filePath);
+
+            // Act
+            RoslynSdkConfiguration loaded = RoslynSdkConfiguration.Load(filePath);
+            string resavedFilePath = Path.Combine(testDir, "resaved.txt");
+            loaded.Save(resavedFilePath);
+            this.TestContext.AddResultFile(resavedFilePath);
+
+            // Assert
+            Assert.AreEqual("example", loaded.PluginKeyDifferentiator);
+            Assert.AreEqual("roslyn.example", loaded.RepositoryKey);
+            Assert.AreEqual("example", loaded.RepositoryLanguage);
+            Assert.AreEqual("example", loaded.RepositoryName);
+            Assert.AreEqual("/org/sonar/plugins/roslynsdk/rules.xml", loaded.RulesXmlResourcePath);
+            Assert.AreEqual("/org/sonar/plugins/roslynsdk/sqale.xml", loaded.SqaleXmlResourcePath);
+
+            AssertPropertyExists("example.pluginKey", "example", loaded.Properties);
+            AssertPropertyExists("example.pluginVersion", "example", loaded.Properties);
+            AssertPropertyExists("example.staticResourceName", "example", loaded.Properties);
+            AssertPropertyExists("example.nuget.packageId", "example", loaded.Properties);
+            AssertPropertyExists("example.nuget.packageVersion", "example", loaded.Properties);
+            AssertPropertyExists("example.analyzerId", "example", loaded.Properties);
+            AssertPropertyExists("example.ruleNamespace", "example", loaded.Properties);
+        }
+
+        #endregion
+
+        #region Private methods
+
+        private static void AssertPropertyExists(string expectedKey, string expectedValue, PluginProperties actualProperties)
+        {
+            Assert.IsTrue(actualProperties.ContainsKey(expectedKey), "Expected key not found: {0}", expectedKey);
+            Assert.AreEqual(expectedValue, actualProperties[expectedKey], "Unexpected value for key '{0}'", expectedKey);
+        }
+
+        #endregion
+
+    }
+}

--- a/Tests/RoslynPluginGeneratorTests/SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.csproj
+++ b/Tests/RoslynPluginGeneratorTests/SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.csproj
@@ -119,6 +119,7 @@
     <Compile Include="..\..\AssemblyInfo.Shared.cs">
       <Link>Properties\AssemblyInfo.Shared.cs</Link>
     </Compile>
+    <Compile Include="RoslynSdkConfigurationTests.cs" />
     <Compile Include="RulesGeneratorTests.cs" />
     <Compile Include="NuGetPackageHandlerTests.cs" />
     <Compile Include="SupportedLanguagesTests.cs" />


### PR DESCRIPTION
We're removing the need to have the JDK installed to create a SonarQube plugin. Instead, we use a template jar file into which we'll inject a number of XML rules: rules, sqale, and a configuration file.

This commit contains the data model and tests for the new configuration file.