### PR TITLE
Feature: Plugins are now able to provide embedded html descriptions for rules

### DIFF
--- a/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
+++ b/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
@@ -28,6 +28,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
             public const string SqaleXmlFile = "sqale.xml";
             public const string AcceptLicenses = "accept.licenses";
             public const string RecurseDependencies = "recurse.dependencies";
+            public const string HtmlDescriptionResourceNamespace = "description.resource.namespace";
         }
 
         private static IList<ArgumentDescriptor> Descriptors;
@@ -46,6 +47,9 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
                 id: KeywordIds.AcceptLicenses, prefixes: new string[] { "/acceptLicenses" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_AcceptLicenses, isVerb: true));
             Descriptors.Add(new ArgumentDescriptor(
                 id: KeywordIds.RecurseDependencies, prefixes: new string[] { "/recurse" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_RecurseDependencies, isVerb: true));
+            Descriptors.Add(new ArgumentDescriptor(
+                id: KeywordIds.HtmlDescriptionResourceNamespace, prefixes: new string[] { "/descriptionNamespace:", "/d:" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_DescriptionResourceNamespace));
+
 
             Debug.Assert(Descriptors.All(d => d.Prefixes != null && d.Prefixes.Any()), "All descriptors must provide at least one prefix");
             Debug.Assert(Descriptors.Select(d => d.Id).Distinct().Count() == Descriptors.Count, "All descriptors must have a unique id");
@@ -119,10 +123,17 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
                     sqaleFilePath,
                     acceptLicense,
                     recurseDependencies,
-                    System.IO.Directory.GetCurrentDirectory());
+                    System.IO.Directory.GetCurrentDirectory(), 
+                    ParseHtmlDescriptionResourceNamespace(arguments));
             }
 
             return processed;
+        }
+
+        private string ParseHtmlDescriptionResourceNamespace(IEnumerable<ArgumentInstance> arguments)
+        {
+            ArgumentInstance argument = arguments.SingleOrDefault(a => ArgumentDescriptor.IdComparer.Equals(KeywordIds.HtmlDescriptionResourceNamespace, a.Descriptor.Id));
+            return argument?.Value;
         }
 
         private bool TryParseAnalyzerRef(IEnumerable<ArgumentInstance> arguments, out NuGetReference analyzerRef)

--- a/RoslynPluginGenerator/CommandLine/CmdLineResources.Designer.cs
+++ b/RoslynPluginGenerator/CommandLine/CmdLineResources.Designer.cs
@@ -79,6 +79,15 @@ namespace SonarQube.Plugins.Roslyn.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to /d:[Namespace] or /descriptionNamespace:[Namespace] - Specifies the resource namespace where the html description are embedded..
+        /// </summary>
+        internal static string ArgDescription_DescriptionResourceNamespace {
+            get {
+                return ResourceManager.GetString("ArgDescription_DescriptionResourceNamespace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to /recurse - search for analyzers in target package and any dependencies.
         /// </summary>
         internal static string ArgDescription_RecurseDependencies {

--- a/RoslynPluginGenerator/CommandLine/CmdLineResources.resx
+++ b/RoslynPluginGenerator/CommandLine/CmdLineResources.resx
@@ -123,6 +123,9 @@
   <data name="ArgDescription_AnalzyerRef" xml:space="preserve">
     <value>/a:[NuGet package id]  or  /a:[NuGet package id]:[version]</value>
   </data>
+  <data name="ArgDescription_DescriptionResourceNamespace" xml:space="preserve">
+    <value>/d:[Namespace] or /descriptionNamespace:[Namespace] - Specifies the resource namespace where the html description are embedded.</value>
+  </data>
   <data name="ArgDescription_RecurseDependencies" xml:space="preserve">
     <value>/recurse - search for analyzers in target package and any dependencies</value>
   </data>

--- a/RoslynPluginGenerator/CommandLine/ProcessedArgs.cs
+++ b/RoslynPluginGenerator/CommandLine/ProcessedArgs.cs
@@ -19,7 +19,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
         private readonly bool recurseDependencies;
         private readonly string outputDirectory;
 
-        public ProcessedArgs(string packageId, SemanticVersion packageVersion, string language, string sqaleFilePath, bool acceptLicenses, bool recurseDependencies, string outputDirectory)
+        public ProcessedArgs(string packageId, SemanticVersion packageVersion, string language, string sqaleFilePath, bool acceptLicenses, bool recurseDependencies, string outputDirectory, string htmlDescriptionResourceNamespace)
         {
             if (string.IsNullOrWhiteSpace(packageId))
             {
@@ -39,6 +39,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
             this.acceptLicenses = acceptLicenses;
             this.recurseDependencies = recurseDependencies;
             this.outputDirectory = outputDirectory;
+            this.HtmlDescriptionResourceNamespace = htmlDescriptionResourceNamespace;
         }
 
         public string PackageId { get { return this.packageId; } }
@@ -54,5 +55,6 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
         public bool RecurseDependencies { get { return this.recurseDependencies; } }
 
         public string OutputDirectory { get { return this.outputDirectory; } }
+        public string HtmlDescriptionResourceNamespace { get; }
     }
 }

--- a/RoslynPluginGenerator/RuleGenerator.cs
+++ b/RoslynPluginGenerator/RuleGenerator.cs
@@ -11,7 +11,10 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
+using System.Reflection;
 using System.Text;
+using SonarQube.Plugins.Roslyn.CommandLine;
 
 namespace SonarQube.Plugins.Roslyn
 {
@@ -23,10 +26,17 @@ namespace SonarQube.Plugins.Roslyn
         public const string Cardinality = "SINGLE";
         public const string Status = "READY";
         private readonly ILogger logger;
+        private readonly string htmlDescriptionResourceNamespace;
 
         public RuleGenerator(ILogger logger)
+            : this(logger, null)
+        {
+        }
+
+        public RuleGenerator(ILogger logger, string htmlDescriptionResourceNamespace)
         {
             this.logger = logger;
+            this.htmlDescriptionResourceNamespace = htmlDescriptionResourceNamespace;
         }
 
         #region IRuleGenerator
@@ -85,7 +95,7 @@ namespace SonarQube.Plugins.Roslyn
                 newRule.Key = diagnostic.Id;
                 newRule.InternalKey = diagnostic.Id;
 
-                newRule.Description = GetDescriptionAsRawHtml(diagnostic);
+                newRule.Description = GetDescription(analyzer, diagnostic);
 
                 newRule.Name = diagnostic.Title.ToString(CultureInfo.InvariantCulture);
                 newRule.Severity = GetSonarQubeSeverity(diagnostic.DefaultSeverity);
@@ -117,10 +127,65 @@ namespace SonarQube.Plugins.Roslyn
         }
 
         /// <summary>
+        /// Returns the description as HTML.
+        /// </summary>
+        private string GetDescription(DiagnosticAnalyzer analyzer, DiagnosticDescriptor diagnostic)
+        {
+            Assembly analyzerAssembly = analyzer.GetType().Assembly;
+            string ruleDescriptionNamespace;
+
+            if (!TryGetResourceName(analyzerAssembly, diagnostic.Id, out ruleDescriptionNamespace))
+                return GetDiagnosticDescriptionAsRawHtml(diagnostic);
+
+            string htmlDescription;
+            if (TryGetResourceContentFromAssembly(analyzerAssembly, ruleDescriptionNamespace, out htmlDescription))
+                return htmlDescription;
+
+            return GetDiagnosticDescriptionAsRawHtml(diagnostic);
+        }
+
+        private bool TryGetResourceName(Assembly assembly, string diagnosticId, out string resourceName)
+        {
+            var manifestResourceNames = assembly.GetManifestResourceNames().AsQueryable();
+            if (string.IsNullOrWhiteSpace(htmlDescriptionResourceNamespace))
+            {
+                manifestResourceNames =
+                    manifestResourceNames.Where(
+                        name =>
+                            name.EndsWith($"Rules.Descriptions.{diagnosticId}.html",
+                                StringComparison.OrdinalIgnoreCase));
+            }
+            else
+            {
+                manifestResourceNames =
+                    manifestResourceNames.Where(name => name.Equals($"{htmlDescriptionResourceNamespace}.{diagnosticId}.html"));
+            }
+
+            resourceName = manifestResourceNames.SingleOrDefault();
+            return !string.IsNullOrWhiteSpace(resourceName);
+        }
+
+        private bool TryGetResourceContentFromAssembly(Assembly assembly, string resourceName, out string resourceContent)
+        {
+            resourceContent = null;
+            using (Stream resourceStream = assembly.GetManifestResourceStream(resourceName))
+            {
+                if (resourceStream == null)
+                    return false;
+
+                using (var streamReader = new StreamReader(resourceStream))
+                {
+                    resourceContent = streamReader.ReadToEnd();
+                    return !string.IsNullOrWhiteSpace(resourceContent);
+                }
+            }
+        }
+
+        /// <summary>
         /// Returns the description as HTML
         /// </summary>
         /// <returns>Note: the description should be returned as the HTML that should be rendered i.e. there is no need enclose it in a CDATA section</returns>
-        private static string GetDescriptionAsRawHtml(DiagnosticDescriptor diagnostic)
+        private static string GetDiagnosticDescriptionAsRawHtml(DiagnosticDescriptor diagnostic)
         {
             StringBuilder sb = new StringBuilder();
             bool hasDescription = false;

--- a/Tests/IntegrationTests/IntegrationTests.csproj
+++ b/Tests/IntegrationTests/IntegrationTests.csproj
@@ -70,6 +70,7 @@
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
       <Private>True</Private>

--- a/Tests/IntegrationTests/Roslyn/RoslynGenTests.cs
+++ b/Tests/IntegrationTests/Roslyn/RoslynGenTests.cs
@@ -43,7 +43,7 @@ namespace SonarQube.Plugins.IntegrationTests
             // Act
             NuGetPackageHandler nuGetHandler = new NuGetPackageHandler(fakeRemotePkgMgr.LocalRepository, localPackageDestination, logger);
             AnalyzerPluginGenerator apg = new AnalyzerPluginGenerator(nuGetHandler, logger);
-            ProcessedArgs args = new ProcessedArgs(packageId, new SemanticVersion("1.0.2"), "cs", null, false, false, outputDir);
+            ProcessedArgs args = new ProcessedArgs(packageId, new SemanticVersion("1.0.2"), "cs", null, false, false, outputDir, null);
             bool result = apg.Generate(args);
 
             // Assert
@@ -78,7 +78,7 @@ namespace SonarQube.Plugins.IntegrationTests
             NuGetPackageHandler nuGetHandler = new NuGetPackageHandler(fakeRemotePkgMgr.LocalRepository, localPackageDestination, logger);
             AnalyzerPluginGenerator apg = new AnalyzerPluginGenerator(nuGetHandler, logger);
             ProcessedArgs args = new ProcessedArgs(targetPkg.Id, targetPkg.Version, "cs", null, false, 
-                true /* generate plugins for dependencies with analyzers*/, outputDir);
+                true /* generate plugins for dependencies with analyzers*/, outputDir, null);
             bool result = apg.Generate(args);
 
             // Assert
@@ -113,7 +113,7 @@ namespace SonarQube.Plugins.IntegrationTests
             NuGetPackageHandler nuGetHandler = new NuGetPackageHandler(fakeRemotePkgMgr.LocalRepository, localPackageDestination, logger);
             AnalyzerPluginGenerator apg = new AnalyzerPluginGenerator(nuGetHandler, logger);
             ProcessedArgs args = new ProcessedArgs(targetPkg.Id, targetPkg.Version, "cs", null, false,
-                true /* generate plugins for dependencies with analyzers*/, outputDir);
+                true /* generate plugins for dependencies with analyzers*/, outputDir, null);
             bool result = apg.Generate(args);
 
             // Assert

--- a/Tests/RoslynPluginGeneratorTests/AnalyzerPluginGeneratorTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/AnalyzerPluginGeneratorTests.cs
@@ -612,7 +612,8 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
                 sqaleFilePath,
                 acceptLicenses,
                 recurseDependencies,
-                outputDirectory);
+                outputDirectory, 
+                null);
             return args;
         }
         

--- a/Tests/RoslynPluginGeneratorTests/ArgumentProcessorTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/ArgumentProcessorTests.cs
@@ -179,6 +179,18 @@ namespace SonarQube.Plugins.Roslyn.PluginGeneratorTests
             AssertArgumentsNotProcessed(actualArgs, logger);
         }
 
+        [TestMethod]
+        public void ArgProc_HtmlDescriptionNamespaceProcessed()
+        {
+            var logger = new TestLogger();
+            var htmlDescriptionNamespace = "Some.Namespace";
+            string[] rawArgs = {"/a:validId", $"/d:{htmlDescriptionNamespace}"};
+
+            ProcessedArgs actualArgs = ArgumentProcessor.TryProcessArguments(rawArgs, logger);
+
+            Assert.AreEqual(actualArgs.HtmlDescriptionResourceNamespace, htmlDescriptionNamespace);
+        }
+
         #endregion
 
         #region Checks

--- a/Tests/RoslynPluginGeneratorTests/DiagnosticAssemblyScannerTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/DiagnosticAssemblyScannerTests.cs
@@ -128,7 +128,7 @@ namespace SonarQube.Plugins.Roslyn.RuleGeneratorTests
 
             Assert_AnalyzerIsPresent(result, typeof(RoslynAnalyzer10.ExampleAnalyzer2));
 
-            Assert.AreEqual(4, result.Count(), "Unexpected number of C# analyzers returned");
+            Assert.AreEqual(5, result.Count(), "Unexpected number of C# analyzers returned");
         }
 
         #region Private Methods

--- a/Tests/RoslynPluginGeneratorTests/Infrastructure/MockedAnalyzer.cs
+++ b/Tests/RoslynPluginGeneratorTests/Infrastructure/MockedAnalyzer.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using RoslynAnalyzer11;
+
+namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.Infrastructure
+{
+    /// <summary>
+    /// A mock analyzer used for getting the correct assembly for loading the rule html desciptions.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, "Test#")]
+    public class MockedAnalyzer : ConfigurableAnalyzer
+    {
+    }
+}

--- a/Tests/RoslynPluginGeneratorTests/Rules.Descriptions/DiagnosticID1.html
+++ b/Tests/RoslynPluginGeneratorTests/Rules.Descriptions/DiagnosticID1.html
@@ -1,0 +1,1 @@
+﻿<p>Some html description</p>

--- a/Tests/RoslynPluginGeneratorTests/RulesGeneratorTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/RulesGeneratorTests.cs
@@ -8,6 +8,8 @@ using RoslynAnalyzer11;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
+using SonarQube.Plugins.Roslyn.CommandLine;
+using SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.Infrastructure;
 using SonarQube.Plugins.Test.Common;
 
 namespace SonarQube.Plugins.Roslyn.RuleGeneratorTests
@@ -94,6 +96,33 @@ namespace SonarQube.Plugins.Roslyn.RuleGeneratorTests
 
                 Assert.AreEqual(rule.Description, UIResources.RuleGen_NoDescription);
             }
+        }
+
+        [TestMethod]
+        public void LoadsHtmlDescriptionsFromResourcesWithoutResourceNamespace()
+        {
+            var logger = new TestLogger();
+            var analyzer = new MockedAnalyzer();
+            analyzer.RegisterDiagnostic(key: "DiagnosticID1", description: "Some plain text description");
+            IRuleGenerator generator = new RuleGenerator(logger);
+
+            Rules rules = generator.GenerateRules(new[] { analyzer });
+
+            Assert.AreEqual(rules.First().Description, "<p>Some html description</p>");
+        }
+
+
+        [TestMethod]
+        public void LoadsHtmlDescriptionsFromResourcesByGivenResourceNamespace()
+        {
+            var logger = new TestLogger();
+            var analyzer = new MockedAnalyzer();
+            analyzer.RegisterDiagnostic(key: "DiagnosticID1", description: "Some plain text description");
+            IRuleGenerator generator = new RuleGenerator(logger, "SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.Rules.Descriptions");
+
+            Rules rules = generator.GenerateRules(new[] {analyzer});
+
+            Assert.AreEqual(rules.First().Description, "<p>Some html description</p>");
         }
 
         #endregion Tests

--- a/Tests/RoslynPluginGeneratorTests/SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.csproj
+++ b/Tests/RoslynPluginGeneratorTests/SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.csproj
@@ -71,6 +71,7 @@
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
       <Private>True</Private>
@@ -97,6 +98,7 @@
       <HintPath>..\..\packages\System.Reflection.Metadata.1.1.0\lib\dotnet5.2\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.XML" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -115,6 +117,7 @@
     <Compile Include="ArchiveUpdaterTests.cs" />
     <Compile Include="ArgumentProcessorTests.cs" />
     <Compile Include="DiagnosticAssemblyScannerTests.cs" />
+    <Compile Include="Infrastructure\MockedAnalyzer.cs" />
     <Compile Include="NuGetMachineWideSettingsTests.cs" />
     <Compile Include="NuGetRepositoryFactoryTests.cs" />
     <Compile Include="Infrastructure\RemoteRepoBuilder.cs" />
@@ -169,6 +172,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="LICENSE.txt" />
+    <EmbeddedResource Include="Rules.Descriptions\DiagnosticID1.html" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">


### PR DESCRIPTION
Hi,

currently, plugins are already able to provide a html description for rules. But the problem is, if we do so, that Visual Studio will not render these html messages. As intended, html descriptions are explicitly for sonarqube. This pull request introduces a new command switch:

`/descriptionNamespace:[namespace to embedded html descriptions]` or `/d:[namespace to embedded html descriptions]`

The rule generator will then look into the assembly to get the embedded html description file for a given rule.

If there is no html description present, it will fallback to the _DiagnosticDescriptor.Description_.

In case that the command line switch is not present, the rule generator will try to load the html resource file from embedded resources by name those are ending with `*.Rules.Descriptions.{RuleId}.html`.

UnitTests are also provided.

Cheers,
 Andy